### PR TITLE
Find bar line numbering issue

### DIFF
--- a/SMLLineNumbers.m
+++ b/SMLLineNumbers.m
@@ -156,7 +156,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
         }
         
         NSLayoutManager *layoutManager = [textView layoutManager];
-        NSRect visibleRect = [[scrollView contentView] documentVisibleRect];
+        NSRect visibleRect = CGRectOffset([[scrollView contentView] documentVisibleRect], 0, 0 - (([scrollView isFindBarVisible]) ? scrollView.findBarView.frame.size.height : 0));
         NSRange visibleRange = [layoutManager glyphRangeForBoundingRect:visibleRect inTextContainer:[textView textContainer]];
         NSInteger location = visibleRange.location;
         NSString *textString = [textView string];


### PR DESCRIPTION
When showing the find bar, the line numbering is incorrect. The textview gets pushed down, but the line number view does not.

![screen shot 2015-10-01 at 10 44 49](https://cloud.githubusercontent.com/assets/34273/10217762/c7775944-6829-11e5-9b1e-1be3fc25937f.png)

After this fix:

![screen shot 2015-10-01 at 10 44 19](https://cloud.githubusercontent.com/assets/34273/10217765/ceda416a-6829-11e5-9e9f-420fa420ff52.png)
